### PR TITLE
Fix some dispatching edge cases

### DIFF
--- a/arraylias/aliased.py
+++ b/arraylias/aliased.py
@@ -81,3 +81,12 @@ class AliasedPath(AliasedModule):
             raise LibraryError(
                 f"{type(first_arg)} is not a registered type for any registered array libraries."
             ) from ex
+
+    def __getattr__(self, attr: str):
+        # Check to avoid dispatching for dunder methods or objects
+        # This to prevent errors that can occur when inspecting
+        # AliasedPath in wrapper methods that treat it like a function
+        # such as with jax.jit
+        if attr.startswith("__") and attr.endswith("__"):
+            raise AttributeError(f"AliasedPath cannot alias dunder attribute ({attr})")
+        return super().__getattr__(attr)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Fixed bug where infer_lib with allow_sequence=True would raise an exception if the input was an empty sequence.
* Add check for AliasedPath so that it does not try and lookup dunder attributes. This was causing issues with attempting to jit AliasedPath functions with jax.
* Fix bug where `alias()` returns an AliasedPath instead of an AliasedModule("auto") for the base module.

### Details and comments


