### PR TITLE
Fix the kind of JAX_TYPES when registering jax

### DIFF
--- a/arraylias/numpy_alias/register_jax.py
+++ b/arraylias/numpy_alias/register_jax.py
@@ -24,6 +24,7 @@ def register_jax(alias):
 
         lib = "jax"
 
+        # pylint: disable = invalid-name
         JAX_TYPES = (Tracer, jax.Array)
         if jax.__version__ <= "0.4.10":
             JAX_TYPES += (jax.interpreters.xla.DeviceArray,)

--- a/arraylias/numpy_alias/register_jax.py
+++ b/arraylias/numpy_alias/register_jax.py
@@ -24,14 +24,9 @@ def register_jax(alias):
 
         lib = "jax"
 
-        if jax.__version__ > "0.4.10":
-            # pylint: disable = invalid-name
-            JAX_TYPES = (Tracer, jax.Array)
-        else:
-            from jax.interpreters.xla import DeviceArray
-
-            # pylint: disable = invalid-name
-            JAX_TYPES = (DeviceArray, Tracer, jax.Array)
+        JAX_TYPES = (Tracer, jax.Array)
+        if jax.__version__ <= "0.4.10":
+            JAX_TYPES += (jax.interpreters.xla.DeviceArray,)
 
         # Register jax types
         for atype in JAX_TYPES:

--- a/arraylias/numpy_alias/register_jax.py
+++ b/arraylias/numpy_alias/register_jax.py
@@ -20,13 +20,18 @@ def register_jax(alias):
     """
     try:
         import jax
-        from jax.interpreters.xla import DeviceArray
         from jax.core import Tracer
 
         lib = "jax"
 
-        # pylint: disable = invalid-name
-        JAX_TYPES = (DeviceArray, Tracer, jax.Array)
+        if jax.__version__ > "0.4.10":
+            # pylint: disable = invalid-name
+            JAX_TYPES = (Tracer, jax.Array)
+        else:
+            from jax.interpreters.xla import DeviceArray
+
+            # pylint: disable = invalid-name
+            JAX_TYPES = (DeviceArray, Tracer, jax.Array)
 
         # Register jax types
         for atype in JAX_TYPES:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
In jax_version 0.4.11, class DeviceArray is just removed.
https://github.com/google/jax/compare/jax-v0.4.11...main

In this PR, I added dispatching when importing DeviceArray in register_jax.

### Details and comments


