### PR TITLE
Make it easy to use random module for jax

### DIFF
--- a/arraylias/alias.py
+++ b/arraylias/alias.py
@@ -16,6 +16,61 @@ from arraylias.aliased import AliasedModule, AliasedPath
 from arraylias.exceptions import AliasError, LibraryError
 
 
+@functools.wraps(functools.lru_cache)
+def method_lru_cache(maxsize: Optional[int] = 128, typed: bool = False) -> Callable:
+    """Least-recently-used cache decorator for methods.
+
+    If *maxsize* is set to None, the LRU features are disabled and the cache
+    can grow without bound.
+
+    If *typed* is True, arguments of different types will be cached separately.
+    For example, f(3.0) and f(3) will be treated as distinct calls with
+    distinct results.
+
+    Arguments to the cached function must be hashable.
+
+    See:  https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)
+    """
+
+    # Construct the functools LRU cache decorator
+    lru_cache = functools.lru_cache(maxsize=maxsize, typed=typed)
+
+    def cache_method_decorator(method: Callable) -> Callable:
+        """Decorator for caching method.
+
+        Args:
+            method: A method to cache.
+
+        Returns:
+            The wrapped cached method.
+        """
+
+        def _get_cache(self):
+            """Retrieve the cache"""
+            try:
+                return getattr(self, "_method_lru_cache")
+            except AttributeError:
+                setattr(self, "_method_lru_cache", {})
+                return getattr(self, "_method_lru_cache")
+
+        @functools.wraps(method)
+        def _cached_method(self, *args, **kwargs):
+            cache = _get_cache(self)
+            key = method.__name__
+            try:
+                # Return the previously cached function
+                meth = cache[key]
+            except KeyError:
+                # Create new cached function and return it
+                meth = cache[key] = lru_cache(functools.partial(method, self))
+
+            return meth(*args, **kwargs)
+
+        return _cached_method
+
+    return cache_method_decorator
+
+
 class Alias:
     """Array library aliasing class.
 
@@ -38,6 +93,7 @@ class Alias:
         "_functions",
         "_fallbacks",
         "_defaults",
+        "_method_lru_cache",
     ]
 
     def __init__(self):
@@ -64,6 +120,9 @@ class Alias:
         # function can't match the array type to a registered type
         self._defaults = {}
 
+        # Cache for LRU cached methods
+        self._method_lru_cache = {}
+
     def __call__(
         self, path: Optional[str] = None, like: Optional[Union[str, type, any]] = None
     ) -> Union[AliasedModule, AliasedPath, Callable]:
@@ -89,12 +148,12 @@ class Alias:
             libs = (lib,)
         return self._dispatch(libs, path)
 
-    @functools.lru_cache(1)
+    @method_lru_cache(1)
     def registered_libs(self) -> Tuple[str, ...]:
         """Return all registered library names for dispatching."""
         return tuple(self._libs)
 
-    @functools.lru_cache(1)
+    @method_lru_cache(1)
     def registered_types(self) -> Tuple[type, ...]:
         """Return all registered types for dispatching."""
         return tuple(self._types)
@@ -294,11 +353,9 @@ class Alias:
     def cache_clear(self):
         """Clear cached dispatched calls."""
         # Clear LRU cached functions
-        self.registered_libs.cache_clear()
-        self.registered_types.cache_clear()
-        self._dispatch.cache_clear()
-        self._split_lib_from_path.cache_clear()
-        self._libs_from_type.cache_clear()
+        for func in self._method_lru_cache.values():
+            func.cache_clear()
+        self._method_lru_cache.clear()
 
     def _register_lib(self, lib: str):
         """Register an array library name.
@@ -423,7 +480,7 @@ class Alias:
 
         return decorator
 
-    @functools.lru_cache(None)
+    @method_lru_cache(512)
     def _dispatch(
         self, libs: Tuple[str, ...], path: Union[str, None]
     ) -> Union[AliasedModule, AliasedPath, Callable]:
@@ -500,7 +557,7 @@ class Alias:
         # Static dispatch failed to match anything for this path and library
         return None
 
-    @functools.lru_cache(None)
+    @method_lru_cache()
     def _libs_from_type(self, obj_type: type) -> Tuple[str, ...]:
         """Return the library name of a type if registered"""
         if obj_type is type(None):
@@ -516,7 +573,7 @@ class Alias:
 
         return tuple()
 
-    @functools.lru_cache(None)
+    @method_lru_cache()
     def _split_lib_from_path(self, path: Union[str, None]) -> Tuple[str, str]:
         """Split lib from path string if present."""
         if path is None:
@@ -531,7 +588,7 @@ class Alias:
         return "auto", path
 
 
-@functools.lru_cache(None)
+@functools.lru_cache()
 def _lib_from_object(obj: any) -> str:
     """Infer array library string from base module path of an object."""
     if isinstance(obj, ModuleType):

--- a/arraylias/alias.py
+++ b/arraylias/alias.py
@@ -163,6 +163,7 @@ class Alias:
         func: Optional[Callable] = None,
         path: Optional[str] = None,
         lib: Optional[str] = None,
+        identity: bool = False,
     ) -> Optional[Callable]:
         """Register an array function for aliasing.
 
@@ -178,12 +179,18 @@ class Alias:
             lib: Optional, a name string to identify the array library.
                  If None this will be set as the base module name of the
                  arrays module.
+            identity: If identity is True, the function that returns inputs themselves
+                 as outputs is registered.
 
         Returns:
             If func is None returns a decorator for registering a function.
             Otherwise returns None.
         """
         decorator = self._register_function_decorator(path=path, lib=lib)
+
+        if identity:
+            func = lambda *x: x[0] if len(x) == 1 else x
+
         if func is None:
             return decorator
         return decorator(func)
@@ -192,6 +199,7 @@ class Alias:
         self,
         func: Optional[Callable] = None,
         path: Optional[str] = None,
+        identity: bool = False,
     ) -> Optional[Callable]:
         """Register a fallback array function for aliasing.
 
@@ -203,12 +211,18 @@ class Alias:
                   If None this will return a decorator to apply to a function.
             path: Optional, the path for dispatching to this function. If None
                   the name of the input function will be used.
+            identity: If identity is True, the function that returns inputs themselves
+                 as outputs is registered as a fallback.
 
         Returns:
             If func is None returns a decorator for registering a function.
             Otherwise returns None.
         """
         decorator = self._register_fallback_decorator(path=path)
+
+        if identity:
+            func = lambda *x: x[0] if len(x) == 1 else x
+
         if func is None:
             return decorator
         return decorator(func)
@@ -217,6 +231,7 @@ class Alias:
         self,
         func: Optional[Callable] = None,
         path: Optional[str] = None,
+        identity: bool = False,
     ) -> Optional[Callable]:
         """Register a default function alias for un-registered types.
 
@@ -228,12 +243,17 @@ class Alias:
                   If None this will return a decorator to apply to a function.
             path: Optional, the path for dispatching to this function. If None
                   the name of the input function will be used.
-
+            identity: If identity is True, the function that returns inputs themselves
+                 as outputs is registered as a default.
         Returns:
             If func is None returns a decorator for registering a function.
             Otherwise returns None.
         """
         decorator = self._register_default_decorator(path=path)
+
+        if identity:
+            func = lambda *x: x[0] if len(x) == 1 else x
+
         if func is None:
             return decorator
         return decorator(func)

--- a/test/alias/test_register_functions.py
+++ b/test/alias/test_register_functions.py
@@ -131,6 +131,17 @@ class TestRegisterFunction(unittest.TestCase):
         func = alias("myfunc", like=lib)
         self.assertEqual(func, myfunc)
 
+    def test_register_function_with_identity(self):
+        """Test register_fucntion with identity"""
+        alias = Alias()
+        alias.register_type(numpy.ndarray, "test_lib")
+
+        alias.register_function(path="supermyfunc", lib="test_lib", identity=True)
+        func = alias("supermyfunc", like="test_lib")
+
+        self.assertEqual(func(1), 1)
+        self.assertEqual(func(1, 2), (1, 2))
+
     def test_register_fallback_default(self):
         """Test register_fallback with default args"""
 
@@ -217,6 +228,17 @@ class TestRegisterFunction(unittest.TestCase):
         func = alias("myfunc", like=lib)
         self.assertEqual(func, myfunc)
 
+    def test_register_fallback_with_identity(self):
+        """Test register_fallback with identity"""
+        alias = Alias()
+        alias.register_type(numpy.ndarray)
+
+        alias.register_fallback(path="myfunc", identity=True)
+        func = alias("myfunc", like=numpy.ndarray)
+
+        self.assertEqual(func(1), 1)
+        self.assertEqual(func(1, 2), (1, 2))
+
     def test_register_default_default(self):
         """Test register_default with default args"""
 
@@ -293,3 +315,13 @@ class TestRegisterFunction(unittest.TestCase):
 
         func = alias("myfunc", like=numpy.ndarray)
         self.assertEqual(func, myfunc)
+
+    def test_register_default_with_identity(self):
+        """Test register_default with identity"""
+        alias = Alias()
+
+        alias.register_default(path="myfunc", identity=True)
+        func = alias("myfunc", like=numpy.ndarray)
+
+        self.assertEqual(func(1), 1)
+        self.assertEqual(func(1, 2), (1, 2))

--- a/test/numpy_alias/jax/test_jax_random.py
+++ b/test/numpy_alias/jax/test_jax_random.py
@@ -1,0 +1,43 @@
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Tests for JAX transformations."""
+
+
+import unittest
+from arraylias import numpy_alias
+
+unp = numpy_alias()("jax")
+
+try:
+    from jax import jit, grad, vmap
+    import jax
+    import jax.numpy as jnp
+except ImportError:
+    pass
+
+
+class TestJAXRandomModule(unittest.TestCase):
+    """Tests that JAX transformations perform as expected on dispatched functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        # skip tests of JAX not installed
+        try:
+            # pylint: disable=import-outside-toplevel
+            import jax
+
+            jax.config.update("jax_enable_x64", True)
+            jax.config.update("jax_platform_name", "cpu")
+        except Exception as err:
+            raise unittest.SkipTest("Skipping jax tests.") from err
+
+    def test_random_seed(self):
+        seed = 123
+        print(jax.linalg.__version__)
+        unp.random_seed(seed)
+        print(_RANDOM_KEY)

--- a/test/numpy_alias/jax/test_jax_random.py
+++ b/test/numpy_alias/jax/test_jax_random.py
@@ -9,16 +9,12 @@
 
 
 import unittest
+
+# pylint: disable=consider-using-from-import
+import scipy.stats as stats
 from arraylias import numpy_alias
 
 unp = numpy_alias()("jax")
-
-try:
-    from jax import jit, grad, vmap
-    import jax
-    import jax.numpy as jnp
-except ImportError:
-    pass
 
 
 class TestJAXRandomModule(unittest.TestCase):
@@ -37,7 +33,20 @@ class TestJAXRandomModule(unittest.TestCase):
             raise unittest.SkipTest("Skipping jax tests.") from err
 
     def test_random_seed(self):
+        """Test the same result by seeting random seed"""
         seed = 123
-        print(jax.linalg.__version__)
         unp.random_seed(seed)
-        print(_RANDOM_KEY)
+        result1 = unp.random_normal()
+        unp.random_seed(seed)
+        result2 = unp.random_normal()
+        self.assertEqual(result1, result2)
+
+    def test_random_normal(self):
+        """Test random output according to a normal distribution"""
+        for _ in range(1000):
+            self.assertTrue(unp.random_uniform() <= 1.0 and unp.random_uniform() >= 0.0)
+
+    def test_random_uniform(self):
+        """Test random output according to a uniform distribution"""
+        _, p_val = stats.normaltest([unp.random_normal() for _ in range(1000)])
+        self.assertTrue(p_val > 0.05)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
In default jax random modules, you have to use PRNGkey for it, which is not easy to use intuitively.

We can become to use some random modules as below

```python
alias(like="jax").random_seed(123)
alias(like="jax").random_normal()
```
This  treatment is similar with
```python
np.random.seed(123)
np.random.normal()
```


### Details and comments
related with https://github.com/Qiskit-Extensions/arraylias/issues/16 .
