### PR TITLE
Removing DeviceArray from jax types

### DIFF
--- a/arraylias/default_alias/register_jax.py
+++ b/arraylias/default_alias/register_jax.py
@@ -24,8 +24,6 @@ def register_jax_types(alias):
 
         # pylint: disable = invalid-name
         JAX_TYPES = (Tracer, jax.Array)
-        if jax.__version__ <= "0.4.10":
-            JAX_TYPES += (jax.interpreters.xla.DeviceArray,)
 
         # Register jax types
         for atype in JAX_TYPES:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`DeviceArray` was removed in JAX `0.4.11`. We were still adding this to the `JAX_TYPES` when registering if the version was `<= 0.4.11`, however it turns out this isn't actually necessary for any version above `0.4.0`. (I discovered this while working on [Dynamics #232](https://github.com/Qiskit-Extensions/qiskit-dynamics/pull/232).

This PR complete removes `DeviceArray` from the JAX types.

### Details and comments


